### PR TITLE
Fixed start/end times in cloudtrail_lookup_events.py

### DIFF
--- a/CloudTrail/cloudtrail_lookup_events.py
+++ b/CloudTrail/cloudtrail_lookup_events.py
@@ -1,10 +1,11 @@
 """
 Retrieve CloudTrail events
 """
-from botocore.exceptions import ProfileNotFound
-import click
-from datetime import datetime, timedelta
 import logging
+from datetime import datetime, timedelta, timezone
+
+import click
+from botocore.exceptions import ProfileNotFound
 from helper.aws import AwsApiHelper
 from helper.ser import dump_json
 
@@ -32,16 +33,23 @@ class Helper(AwsApiHelper):
 def new_operation_params(start_time, end_time, event_name, user_name):
     end_dt = datetime.now() if end_time is None else datetime.strptime(end_time, "%Y-%m-%d")
     start_dt = end_dt - timedelta(hours=LOOKUP_HOURS) if start_time is None else datetime.strptime(start_time, "%Y-%m-%d")
-    
+
+    # Convert local datetime to UTC
+    local_to_utc = lambda dt: datetime.utcfromtimestamp(datetime.timestamp(dt))
+
+    end_dt = local_to_utc(end_dt)
+    start_dt = local_to_utc(start_dt)
+
     lookup_attributes = []  # If more than one attribute, they are evaluated as "OR".
     if event_name is not None:
         lookup_attributes.append({"AttributeKey": "EventName", "AttributeValue": event_name})
     if user_name is not None:
         lookup_attributes.append({"AttributeKey": "Username", "AttributeValue": user_name})
-    
+
     operation_params = {"StartTime": start_dt, "EndTime": end_dt}
     if lookup_attributes:
         operation_params["LookupAttributes"] = lookup_attributes
+
     return operation_params
 
 

--- a/CloudTrail/cloudtrail_lookup_events.py
+++ b/CloudTrail/cloudtrail_lookup_events.py
@@ -2,7 +2,7 @@
 Retrieve CloudTrail events
 """
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 import click
 from botocore.exceptions import ProfileNotFound


### PR DESCRIPTION
Fixed cloudtrail_lookup_events.py where startt/end times passing to cloudtrail api shall be in utc